### PR TITLE
Fix proxy to forward JSON bodies

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -6,6 +6,9 @@ import { serveStatic, log } from "./vite";
 
 const app = express();
 
+// Parse JSON request bodies so proxy requests can forward them correctly
+app.use(express.json());
+
 // Serve static files from the static directory for uploaded assets
 app.use('/static', express.static(path.resolve(process.cwd(), 'static')));
 


### PR DESCRIPTION
## Summary
- register express.json() middleware so POST bodies are parsed before proxying to FastAPI

## Testing
- npm run check *(fails: existing TypeScript errors in client and server unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d052a6bee0832a944c20e47294b181